### PR TITLE
Feature: Travel Costs

### DIFF
--- a/Runtime/NativeFlowField.cs
+++ b/Runtime/NativeFlowField.cs
@@ -111,7 +111,7 @@ namespace FlowFieldAI
         // ─────────────────────────────────────────────────────────────
         // Private Fields
         // ─────────────────────────────────────────────────────────────
-        private ComputeBuffer travelCostsBuffer; 
+        private ComputeBuffer travelCostsBuffer;
         private readonly bool useTravelCosts;
 
         private readonly ComputeShader integrationComputeShader;
@@ -335,7 +335,7 @@ namespace FlowFieldAI
                 ? Mathf.Min(iterationsRemaining, bakeOptions.IterationsPerFrame)
                 : Mathf.Min(iterationsRemaining, bakeOptions.Iterations);
 
-            // Initialize compute buffer  with input field
+            // Initialize compute buffer with input field
             if (bakeContext.CurrentIteration == 0 && initializeNewBake)
             {
                 commandBuffer.SetBufferData(integrationFrontBuffer, inputField);
@@ -389,7 +389,7 @@ namespace FlowFieldAI
             commandBuffer.SetComputeIntParam(generateFlowFieldComputeShader, ShaderProperties.Width, Width);
             commandBuffer.SetComputeIntParam(generateFlowFieldComputeShader, ShaderProperties.Height, Height);
             commandBuffer.SetComputeIntParam(generateFlowFieldComputeShader, ShaderProperties.DiagonalMovement, bakeContext.Options.DiagonalMovement ? 1 : 0);
-            commandBuffer.SetComputeIntParam(integrationComputeShader, ShaderProperties.UseTravelCosts, useTravelCosts ? 1 : 0);
+            commandBuffer.SetComputeIntParam(generateFlowFieldComputeShader, ShaderProperties.UseTravelCosts, useTravelCosts ? 1 : 0);
             commandBuffer.SetComputeBufferParam(generateFlowFieldComputeShader, generateFlowFieldComputeShaderKernel, ShaderProperties.InputCosts, integrationFrontBuffer);
             commandBuffer.SetComputeBufferParam(generateFlowFieldComputeShader, generateFlowFieldComputeShaderKernel, ShaderProperties.OutputFlowField, flowFieldBuffer);
             commandBuffer.SetComputeBufferParam(generateFlowFieldComputeShader, generateFlowFieldComputeShaderKernel, ShaderProperties.TravelCosts, travelCostsBuffer);

--- a/Runtime/Resources/GenerateFlowField.compute
+++ b/Runtime/Resources/GenerateFlowField.compute
@@ -37,8 +37,10 @@ int getFlow(uint x, uint y)
                 if (InputCosts[flatten(x, y + offsets[i].y, Width)] >= FLT_MAX-1) continue;
             }
             uint neighborIndex = flatten(nx, ny, Width);
-            float neighborCost = InputCosts[neighborIndex];
-            if (UseTravelCosts) neighborCost += TravelCosts[neighborIndex]; // Add travel cost
+            float neighborCost;
+
+            if (UseTravelCosts) neighborCost = InputCosts[neighborIndex] + TravelCosts[neighborIndex]; // Add travel cost
+            else neighborCost = InputCosts[neighborIndex];
 
             if (neighborCost < FLT_MAX && neighborCost > FLT_MIN)
             {

--- a/Runtime/Resources/GenerateFlowField.compute
+++ b/Runtime/Resources/GenerateFlowField.compute
@@ -5,6 +5,8 @@
 uint Width;
 uint Height;
 int DiagonalMovement;
+int UseTravelCosts;
+StructuredBuffer<float> TravelCosts;
 StructuredBuffer<float> InputCosts;
 RWStructuredBuffer<int> OutputFlowField;
 
@@ -36,6 +38,7 @@ int getFlow(uint x, uint y)
             }
             uint neighborIndex = flatten(nx, ny, Width);
             float neighborCost = InputCosts[neighborIndex];
+            if (UseTravelCosts) neighborCost += TravelCosts[neighborIndex]; // Add travel cost
 
             if (neighborCost < FLT_MAX && neighborCost > FLT_MIN)
             {

--- a/Runtime/Resources/GenerateIntegrationField.compute
+++ b/Runtime/Resources/GenerateIntegrationField.compute
@@ -25,7 +25,7 @@ float getMinCost(uint x, uint y)
         int nx = x + offsets[i].x;
         int ny = y + offsets[i].y;
 
-        if (nx >= 0 && (uint) nx < Width && ny >= 0 && (uint) ny < Height)
+        if (nx >= 0 && (uint)nx < Width && ny >= 0 && (uint)ny < Height)
         {
             bool isDiagonal = i >= 4;
             if (isDiagonal)
@@ -38,6 +38,7 @@ float getMinCost(uint x, uint y)
             }
             uint neighborIndex = flatten(nx, ny, Width);
             float neighborCost = InputCosts[neighborIndex];
+            if (UseTravelCosts) neighborCost += TravelCosts[neighborIndex]; // Add travel cost
 
             if (neighborCost < FLT_MAX && neighborCost > FLT_MIN)
             {
@@ -45,16 +46,11 @@ float getMinCost(uint x, uint y)
                 if (minCost <= FLT_MIN) // Free
                     minCost = neighborCost + stepCost;
                 else
-                    // minCost = min(minCost, neighborCost + stepCost);
                     minCost = min(minCost, neighborCost + stepCost);
             }
         }
     }
 
-    if (UseTravelCosts)
-    {
-        minCost = min(FLT_MAX, minCost + TravelCosts[flatten(x, y, Width)]); // Add travel cost
-    }
     return minCost;
 }
 

--- a/Runtime/Resources/GenerateIntegrationField.compute
+++ b/Runtime/Resources/GenerateIntegrationField.compute
@@ -37,8 +37,10 @@ float getMinCost(uint x, uint y)
                     continue;
             }
             uint neighborIndex = flatten(nx, ny, Width);
-            float neighborCost = InputCosts[neighborIndex];
-            if (UseTravelCosts) neighborCost += TravelCosts[neighborIndex]; // Add travel cost
+            
+            float neighborCost;
+            if (UseTravelCosts) neighborCost = InputCosts[neighborIndex] + TravelCosts[neighborIndex]; // Add travel cost
+            else neighborCost = InputCosts[neighborIndex];
 
             if (neighborCost < FLT_MAX && neighborCost > FLT_MIN)
             {

--- a/Runtime/Resources/GenerateIntegrationField.compute
+++ b/Runtime/Resources/GenerateIntegrationField.compute
@@ -5,6 +5,8 @@
 uint Width;
 uint Height;
 int DiagonalMovement;
+int UseTravelCosts;
+StructuredBuffer<float> TravelCosts;
 StructuredBuffer<float> InputCosts;
 RWStructuredBuffer<float> OutputCosts;
 
@@ -23,14 +25,16 @@ float getMinCost(uint x, uint y)
         int nx = x + offsets[i].x;
         int ny = y + offsets[i].y;
 
-        if (nx >= 0 && (uint)nx < Width && ny >= 0 && (uint)ny < Height)
+        if (nx >= 0 && (uint) nx < Width && ny >= 0 && (uint) ny < Height)
         {
             bool isDiagonal = i >= 4;
             if (isDiagonal)
             {
                 // Both orthogonal must be free
-                if (InputCosts[flatten(x + offsets[i].x, y, Width)] >= FLT_MAX-1) continue;
-                if (InputCosts[flatten(x, y + offsets[i].y, Width)] >= FLT_MAX-1) continue;
+                if (InputCosts[flatten(x + offsets[i].x, y, Width)] >= FLT_MAX - 1)
+                    continue;
+                if (InputCosts[flatten(x, y + offsets[i].y, Width)] >= FLT_MAX - 1)
+                    continue;
             }
             uint neighborIndex = flatten(nx, ny, Width);
             float neighborCost = InputCosts[neighborIndex];
@@ -41,11 +45,16 @@ float getMinCost(uint x, uint y)
                 if (minCost <= FLT_MIN) // Free
                     minCost = neighborCost + stepCost;
                 else
+                    // minCost = min(minCost, neighborCost + stepCost);
                     minCost = min(minCost, neighborCost + stepCost);
             }
         }
     }
 
+    if (UseTravelCosts)
+    {
+        minCost = min(FLT_MAX, minCost + TravelCosts[flatten(x, y, Width)]); // Add travel cost
+    }
     return minCost;
 }
 


### PR DESCRIPTION
I've added support for travel costs. Before, any cell with a weight other than `float.MaxValue` was essentially treated as fully walkable. However, in some games, it may be beneficial if navigation agents also took into account how much "effort" it takes to travel through a certain cell, in combination with that cell's weight.

E.g. consider an environment where enemies can spend time to destroy obstacles in their path. Ideally, enemies would weigh the option of pathfinding around a destroyable obstacle against the option of destroying it and walking through. However, with the current system, enemies will only ever pathfind around _impassable_ obstacles. Any other cell is treated as if it is completely walkable, as it always inherits its neighbor's weight directly (with the distance added).

To adapt it to this type of scenario, I've added another _travel costs_ buffer to optionally be included in the integration step. If travel costs are used, the travel cost of a cell is _added_ to its own minimum cost, reflecting that the benefit of travelling to this cell is _offset_ by the cost of doing so.

Additionally (although I didn't make this change), this removes the need for the "Walkable" and "Obstacle" sentinel values. You can instead initialize all cell weights to `float.MaxValue` (indicating no value), and then set the travel cost of any "Obstacle" to `float.MaxValue`. Walkable cells are simply the default, i.e. a cell with a weight of `float.MaxValue` and travel cost of `0`.

